### PR TITLE
🔧 포스트 상세페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,6 +50,11 @@ function Main() {
               <Route path="/product" element={<Product />}></Route>
               <Route path="/profileedit" element={<ProfileEdit />}></Route>
               <Route path={"*"} element={<NotFound />}></Route>
+              <Route
+                path="/:accountname/:postid"
+                element={<CommentPage />}
+              ></Route>
+              {/* <Route path="/:postid" element={<CommentPage />}></Route> */}
             </>
           ) : (
             // TODO 만약 url로 접근하려고 할 때 로그인 창으로 넘어가도록 추가

--- a/src/components/button/CommentBtn.jsx
+++ b/src/components/button/CommentBtn.jsx
@@ -1,9 +1,22 @@
+import { useNavigate } from "react-router-dom";
 import "./CommentBtn.scss";
 
-function CommentBtn({ commentcount, postid }) {
+function CommentBtn({ commentcount, postid, from, accountname }) {
+  const navigate = useNavigate();
+  const style = from === "comment" ? { pointerEvents: "none" } : null;
+
+  function handleClick() {
+    from === "home" && navigate(accountname + "/" + postid);
+    from === "profile" && navigate(postid);
+  }
   return (
     <div className="wrapper-btn-comment">
-      <button type="button" className="btn-comment">
+      <button
+        type="button"
+        className="btn-comment"
+        style={style}
+        onClick={handleClick}
+      >
         <span className="a11y-hidden">댓글</span>
       </button>
       <span className="text-comment-num">{commentcount || 0}</span>

--- a/src/components/post/Article.jsx
+++ b/src/components/post/Article.jsx
@@ -1,0 +1,71 @@
+import CommentBtn from "../button/CommentBtn";
+import LikeBtn from "../button/LikeBtn";
+import UserMoreBtn from "../button/UserMoreBtn";
+import UserInfoBox from "../user/UserInfoBox";
+import "./Post.scss";
+import { Link } from "react-router-dom";
+
+function Article({ content, from }) {
+  const post = content;
+  const author = content.author;
+  const accountname = author.accountname;
+  const createAt = new Date(content.createdAt);
+  return (
+    <>
+      <article className="article-post">
+        <h3 className="a11y-hidden">user의 post</h3>
+        {from === "profile" ? (
+          <>
+            <UserInfoBox
+              type="post"
+              name={author.username}
+              id={"@" + author.accountname}
+              img={author.image}
+            ></UserInfoBox>
+          </>
+        ) : (
+          <>
+            <Link to={"/" + accountname}>
+              <UserInfoBox
+                type="post"
+                name={author.username}
+                id={"@" + author.accountname}
+                img={author.image}
+              ></UserInfoBox>
+            </Link>
+          </>
+        )}
+
+        <main className="contents-post">
+          <p className="text-post">{post.content}</p>
+          <div className="container-post-image">
+            {post.image === "" ? null : (
+              <img src={post.image} alt="게시글 사진" className="img-post" />
+            )}
+          </div>
+          <div className="container-btn-post">
+            <LikeBtn heartcount={post.heartcount} postid={post.id} />
+            <CommentBtn
+              commentcount={post.commentcount}
+              postid={post.id}
+              post={post}
+              from={from}
+              accountname={accountname}
+            />
+          </div>
+          <strong className="text-post-date">
+            {createAt.getFullYear() +
+              "년 " +
+              (createAt.getMonth() + 1) +
+              "월 " +
+              createAt.getDate() +
+              "일"}
+          </strong>
+        </main>
+        <UserMoreBtn />
+      </article>
+    </>
+  );
+}
+
+export default Article;

--- a/src/components/post/Post.jsx
+++ b/src/components/post/Post.jsx
@@ -1,64 +1,11 @@
-import CommentBtn from "../button/CommentBtn";
-import LikeBtn from "../button/LikeBtn";
-import UserMoreBtn from "../button/UserMoreBtn";
-import UserInfoBox from "../user/UserInfoBox";
 import "./Post.scss";
-import { Link } from "react-router-dom";
+import Article from "./Article";
 
 function Post({ content, from }) {
-  const post = content;
-  const author = content.author;
-  const accountname = author.accountname;
-  const createAt = new Date(content.createdAt);
   return (
     <>
       <li className="item-post">
-        <article className="article-post">
-          <h3 className="a11y-hidden">user의 post</h3>
-          {from === "profile" ? (
-            <>
-              <UserInfoBox
-                type="post"
-                name={author.username}
-                id={"@" + author.accountname}
-                img={author.image}
-              ></UserInfoBox>
-            </>
-          ) : (
-            <>
-              <Link to={"/" + accountname}>
-                <UserInfoBox
-                  type="post"
-                  name={author.username}
-                  id={"@" + author.accountname}
-                  img={author.image}
-                ></UserInfoBox>
-              </Link>
-            </>
-          )}
-
-          <main className="contents-post">
-            <p className="text-post">{post.content}</p>
-            <div className="container-post-image">
-              {post.image === "" ? null : (
-                <img src={post.image} alt="게시글 사진" className="img-post" />
-              )}
-            </div>
-            <div className="container-btn-post">
-              <LikeBtn heartcount={post.heartcount} postid={post.id} />
-              <CommentBtn commentcount={post.commentcount} postid={post.id} />
-            </div>
-            <strong className="text-post-date">
-              {createAt.getFullYear() +
-                "년 " +
-                (createAt.getMonth() + 1) +
-                "월 " +
-                createAt.getDate() +
-                "일"}
-            </strong>
-          </main>
-          <UserMoreBtn />
-        </article>
+        <Article content={content} from={from} />
       </li>
     </>
   );

--- a/src/pages/profile/commentPage/CommentPage.jsx
+++ b/src/pages/profile/commentPage/CommentPage.jsx
@@ -2,15 +2,41 @@ import "./CommentPage.scss";
 import CommonHeader from "../../../components/header/CommonHeader";
 import CommentFooter from "../../../components/footer/CommentFooter";
 import CommentList from "./CommentList";
-import Post from "../../../components/post/Post";
+import { useParams } from "react-router-dom";
+import { useContext, useState, useEffect } from "react";
+import UserContext from "../../../context/UserContext";
+import axios from "axios";
+import Article from "../../../components/post/Article";
 
 function CommentPage() {
+  const { token } = useContext(UserContext);
+  const params = useParams();
+  const postid = params.postid;
+  const [post, setPost] = useState();
+
+  useEffect(() => {
+    const authToken = "Bearer " + token;
+    const url = "https://mandarin.api.weniv.co.kr/post/" + postid;
+    async function getUser() {
+      try {
+        const res = await axios.get(url, {
+          headers: {
+            Authorization: authToken,
+            "Content-type": "application/json",
+          },
+        });
+        setPost(res.data.post);
+      } catch (err) {}
+    }
+    getUser();
+  }, [postid, token]);
+
   return (
     <>
       <CommonHeader />
       <main className="container-comment-page">
         <div className="wrapper-comment-post">
-          <Post />
+          {post && <Article content={post} from="comment" />}
         </div>
         <CommentList />
       </main>


### PR DESCRIPTION
1. 피드와 프로필 페이지에서 포스트 댓글버튼 클릭시에 상세페이지로 이동하도록 기능 추가
2. 포스트 상세페이지에서 댓글버튼 클릭시에는 클릭이벤트 없도록 예외처리
