### PR TITLE
🔧:  프로필 수정 시 로컬스토리지에 accountname 수정

### DIFF
--- a/src/pages/profileEdit/ProfileEdit.jsx
+++ b/src/pages/profileEdit/ProfileEdit.jsx
@@ -9,7 +9,7 @@ import ProfileEditInfo from "./ProfileEditInfo";
 function ProfileEdit() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { token } = useContext(UserContext);
+  const { token, myAccountname, setMyAccountname } = useContext(UserContext);
   const authToken = "Bearer " + token;
   const [user, setUser] = useState("");
   const [username, setUsername] = useState(location.state.username);
@@ -53,6 +53,7 @@ function ProfileEdit() {
       intro: intro,
       image: image,
     });
+    setMyAccountname(accountname);
   }
 
   function handleSubmit(e) {


### PR DESCRIPTION
1. 프로필 수정 시 로컬스토리지 accountname은 그대로여서 개인프로필경로는 바뀌지 않는 오류를 발견하여 해당 기능을 추가했습니다.