### PR TITLE
🔧 스크롤시에 댓글 데이터 추가요청 기능 추가

### DIFF
--- a/src/components/footer/CommentFooter.jsx
+++ b/src/components/footer/CommentFooter.jsx
@@ -31,7 +31,7 @@ function CommentFooter({ postid, post, setNewComment, newComment }) {
           "Content-type": "application/json",
         },
       });
-      setNewComment(!newComment);
+      setNewComment(false);
     } catch (err) {}
   }
 


### PR DESCRIPTION
스크롤로 댓글데이터를 10개씩 추가요청할 수 있습니다.
실시간 댓글 작성시에 10번째 데이터와 11번째 데이터가 중복되는 오류 해결하였습니다.
TODO
- 피드에 infinite scroll 반영
- 댓글 로딩중임을 알려주는 ui 추가