### PR TITLE
🧹 포스트 댓글 빈값 요청 이슈, 유효성 ui 추가

### DIFF
--- a/src/components/footer/CommentFooter.jsx
+++ b/src/components/footer/CommentFooter.jsx
@@ -20,6 +20,8 @@ function CommentFooter({ postid, post, setNewComment }) {
   function handleChange(e) {
     setComment(e.target.value);
   }
+
+  // 댓글 빈 값 요청할 수 없도록 상태 변경
   useEffect(() => {
     comment && comment.length > 0 ? setValid(true) : setValid(false);
   }, [comment]);
@@ -36,7 +38,9 @@ function CommentFooter({ postid, post, setNewComment }) {
         },
       });
       setNewComment(false);
-    } catch (err) {}
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   function handleSubmit(e) {


### PR DESCRIPTION
아래 PR과 다른 기능이라 따로 PR 요청 돼야 하는데, 묶여서 merge 됐네요..ㅠ.ㅠ
포스트 페이지의 댓글 빈값일 경우 요청할 수 없도록 기능 추가했습니다.