### PR TITLE
🔧 모든 무한스크롤 기능 추가, 페이지 이동시 스크롤 제일 위로 오게

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { React, useContext, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import ScrollToTop from "./scrollRestoration/ScrollToTop";
 import axios from "axios";
 import UserContext, { UserContextProvider } from "./context/UserContext";
 import { ImageTestContextProvider } from "./context/ImageTestContext";
@@ -63,6 +64,7 @@ function Main() {
   return (
     <div className="App">
       <BrowserRouter>
+        <ScrollToTop />
         <Routes>
           {token ? (
             <>

--- a/src/pages/emailLoginPage/EmailLoginPage.jsx
+++ b/src/pages/emailLoginPage/EmailLoginPage.jsx
@@ -59,7 +59,6 @@ function EmailLoginPage() {
           },
         }
       );
-
       const data = res.data;
 
       if (data.message === "이메일 또는 비밀번호가 일치하지 않습니다.") {

--- a/src/pages/followPage/FollowPage.jsx
+++ b/src/pages/followPage/FollowPage.jsx
@@ -1,4 +1,4 @@
-import { React, useState, useContext, useEffect } from "react";
+import { React, useState, useContext, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import UserContext from "../../context/UserContext";
 import axios from "axios";
@@ -15,14 +15,23 @@ function FollowPage() {
   const followtype = params.followtype;
   const [followList, setFollowList] = useState([]);
   const [view, setView] = useState("pending");
+  const Container = useRef();
+  const [reloadNeed, setReloadNeed] = useState(false);
+  const [reloadStop, setReloadStop] = useState(false);
+  const [updatedCount, setUpdatedCount] = useState(0);
+  const [skip, setSkip] = useState(0);
 
   useEffect(() => {
-    const url =
-      "https://mandarin.api.weniv.co.kr/profile/" +
-      accountname +
-      "/" +
-      followtype;
+    // 팔로우 리스트 불러오기
     async function getFollowList() {
+      const url =
+        "https://mandarin.api.weniv.co.kr/profile/" +
+        accountname +
+        "/" +
+        followtype +
+        "?limit=15" +
+        "&skip=" +
+        skip;
       try {
         const res = await axios.get(url, {
           headers: {
@@ -36,6 +45,7 @@ function FollowPage() {
         setView("rejected");
       }
     }
+
     // 잘못된 url 예외처리
     if (followtype === "follower" || followtype === "following") {
       accountname && getFollowList();
@@ -44,10 +54,64 @@ function FollowPage() {
     }
   }, [token, accountname, followtype]);
 
+  useEffect(() => {
+    // 화면 마지막에 도달하면 ReloadNeed!
+    function infinitScoll() {
+      const targetHeight = Math.floor(
+        Container.current.getBoundingClientRect().height
+      );
+      const currentScrollY = Math.floor(window.scrollY + window.innerHeight);
+      targetHeight < currentScrollY && setReloadNeed(true);
+    }
+
+    window.addEventListener("scroll", infinitScoll);
+
+    // 스크롤시 데이터 추가 요청 함수
+    async function getFollowList() {
+      const url =
+        "https://mandarin.api.weniv.co.kr/profile/" +
+        accountname +
+        "/" +
+        followtype +
+        "?limit=15" +
+        "&skip=" +
+        skip;
+      try {
+        const res = await axios.get(url, {
+          headers: {
+            Authorization: token,
+            "Content-type": "application/json",
+          },
+        });
+        // 첫 데이터면 전체 데이터 받아오기/데이터가 있으면 스프레드 문법 사용하여 추가하기
+        if (skip === 0) {
+          setFollowList(res.data);
+        } else {
+          setFollowList([...followList, ...res.data]);
+        }
+        // 배열이 비어있으면 데이터 요청 차단
+        res.data.length === 0 && setReloadStop(true);
+        setUpdatedCount(updatedCount + 1);
+        setReloadNeed(false);
+        setSkip(skip + 15);
+      } catch (err) {
+        setView("rejected");
+      }
+    }
+    // 화면 마지막에 도달하면 infinite scroll 시작
+    if (reloadNeed === true) {
+      reloadStop || getFollowList();
+    }
+    // 언마운트시에 스크롤이벤트 발생하지 않도록!
+    return () => {
+      window.removeEventListener("scroll", infinitScoll);
+    };
+  }, [token, followList, updatedCount, reloadNeed, skip, view]);
+
   return (
     <>
       <FollowHeader title="Followers" />
-      <main className="container-follow">
+      <main className="container-follow" ref={Container}>
         {view === "fulfilled" && (
           <div className="wrapper-follow">
             <ul className="wrapper-list-follow">

--- a/src/pages/homePage/HomePage.jsx
+++ b/src/pages/homePage/HomePage.jsx
@@ -22,7 +22,7 @@ function HomePage() {
   const [skip, setSkip] = useState(0);
 
   useEffect(() => {
-    // 실시간 업로드 댓글 반영 함수
+    // 포스트 불러오기
     async function getPosts() {
       const url =
         "https://mandarin.api.weniv.co.kr/post/feed" +
@@ -36,7 +36,6 @@ function HomePage() {
             "Content-type": "application/json",
           },
         });
-        setSkip(0);
         setPosts(res.data.posts);
         setView("fulfilled");
       } catch (err) {

--- a/src/pages/homePage/HomePage.jsx
+++ b/src/pages/homePage/HomePage.jsx
@@ -1,4 +1,4 @@
-import { React, useContext, useEffect, useState } from "react";
+import { React, useContext, useEffect, useState, useRef } from "react";
 import UserContext from "../../context/UserContext";
 import axios from "axios";
 import PostList from "../../components/post/PostList";
@@ -15,12 +15,20 @@ function HomePage() {
   const { token, initialToken } = useContext(UserContext);
   const [posts, setPosts] = useState();
   const [view, setView] = useState("pending");
+  const Container = useRef();
+  const [reloadNeed, setReloadNeed] = useState(false);
+  const [reloadStop, setReloadStop] = useState(false);
+  const [updatedCount, setUpdatedCount] = useState(0);
+  const [skip, setSkip] = useState(0);
 
   useEffect(() => {
-    async function getPost() {
-      // 팔로잉 유저의 포스트 받아오기
-      const url = "https://mandarin.api.weniv.co.kr/post/feed";
-
+    // 실시간 업로드 댓글 반영 함수
+    async function getPosts() {
+      const url =
+        "https://mandarin.api.weniv.co.kr/post/feed" +
+        "/?limit=15" +
+        "&skip=" +
+        skip;
       try {
         const res = await axios.get(url, {
           headers: {
@@ -28,15 +36,69 @@ function HomePage() {
             "Content-type": "application/json",
           },
         });
+        setSkip(0);
         setPosts(res.data.posts);
         setView("fulfilled");
       } catch (err) {
-        console.error(err);
         setView("rejected");
       }
     }
-    initialToken && getPost();
-  }, [initialToken]);
+    getPosts();
+  }, [token, view]);
+
+  useEffect(() => {
+    // 화면 마지막에 도달하면 ReloadNeed!
+    function infinitScoll() {
+      const targetHeight = Math.floor(
+        Container.current.getBoundingClientRect().height
+      );
+      const currentScrollY = Math.floor(
+        window.scrollY + window.innerHeight - 50
+      );
+      targetHeight < currentScrollY && setReloadNeed(true);
+    }
+
+    window.addEventListener("scroll", infinitScoll);
+
+    // 스크롤시 데이터 추가 요청 함수
+    async function getPosts() {
+      const url =
+        "https://mandarin.api.weniv.co.kr/post/feed" +
+        "/?limit=15" +
+        "&skip=" +
+        skip;
+      try {
+        const res = await axios.get(url, {
+          headers: {
+            Authorization: token,
+            "Content-type": "application/json",
+          },
+        });
+        // 첫 데이터면 전체 데이터 받아오기/데이터가 있으면 스프레드 문법 사용하여 추가하기
+        if (skip === 0) {
+          setPosts(res.data.posts);
+        } else {
+          setPosts([...posts, ...res.data.posts]);
+        }
+        // 배열이 비어있으면 데이터 요청 차단
+        res.data.posts.length === 0 && setReloadStop(true);
+        setUpdatedCount(updatedCount + 1);
+        setReloadNeed(false);
+        setSkip(skip + 15);
+      } catch (err) {
+        setView("rejected");
+      }
+    }
+    // 화면 마지막에 도달하면 infinite scroll 시작
+    if (reloadNeed === true) {
+      reloadStop || getPosts();
+    }
+    // 언마운트시에 스크롤이벤트 발생하지 않도록!
+    return () => {
+      window.removeEventListener("scroll", infinitScoll);
+    };
+  }, [token, posts, updatedCount, reloadNeed, skip, initialToken, view]);
+
   return (
     <>
       {sessionStorage.getItem("splash") ? null : <Splash />}
@@ -49,7 +111,7 @@ function HomePage() {
               <main className="main-home feed">
                 <section className="container-post feed">
                   <div className="wrapper-post">
-                    <ol className="list-posts">
+                    <ol className="list-posts" ref={Container}>
                       <PostList post={posts} from="home" />
                     </ol>
                   </div>

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -63,8 +63,10 @@ function ProfilePage() {
         <h1 className="a11y-hidden">{user.username + "의 프로필"}</h1>
         {view === "fulfilled" && (
           <>
-            <UserHeader from={from} user={user} setUser={setUser} />
-            <UserProducts accountname={accountname}  />
+            <div className="wrapper-for-scroll">
+              <UserHeader from={from} user={user} setUser={setUser} />
+              <UserProducts accountname={accountname} />
+            </div>
             <UserPost accountname={accountname} from="profile" />
           </>
         )}

--- a/src/pages/profilePage/userPost/UserPost.jsx
+++ b/src/pages/profilePage/userPost/UserPost.jsx
@@ -14,17 +14,19 @@ function UserPost({ accountname, from }) {
   const [listClicked, setListClicked] = useState("on");
   const [albumClicked, setAlbumClicked] = useState("off");
 
-  // post 삭제 후 업데이트 위한 함수 선언, props로 넘겨주기 위함
-  const { remove, isUpdate } = useDelete();
   const [reloadNeed, setReloadNeed] = useState(false);
   const [reloadStop, setReloadStop] = useState(false);
   const [updatedCount, setUpdatedCount] = useState(0);
   const [skip, setSkip] = useState(0);
 
+  // post 삭제 후 업데이트 위한 함수 선언, props로 넘겨주기 위함
+  const { remove, isUpdate } = useDelete();
+
   useEffect(() => {
     // 포스트 불러오기
+    setSkip(0);
+    setReloadStop(false);
     async function getPost() {
-      setSkip(0);
       const url =
         "https://mandarin.api.weniv.co.kr/post/" +
         accountname +

--- a/src/pages/profilePage/userPost/UserPost.jsx
+++ b/src/pages/profilePage/userPost/UserPost.jsx
@@ -1,4 +1,4 @@
-import { React, useEffect, useContext, useState } from "react";
+import { React, useEffect, useContext, useState, useRef } from "react";
 import UserContext from "../../../context/UserContext";
 import axios from "axios";
 import useDelete from "../../../hooks/useDelete";
@@ -9,17 +9,29 @@ function UserPost({ accountname, from }) {
   const { token } = useContext(UserContext);
   const [post, setPost] = useState();
   const [reloadePost, setReloadPost] = useState(true);
+  const Container = useRef();
   const [postView, setPostView] = useState("list");
   const [listClicked, setListClicked] = useState("on");
   const [albumClicked, setAlbumClicked] = useState("off");
 
   // post 삭제 후 업데이트 위한 함수 선언, props로 넘겨주기 위함
   const { remove, isUpdate } = useDelete();
+  const [reloadNeed, setReloadNeed] = useState(false);
+  const [reloadStop, setReloadStop] = useState(false);
+  const [updatedCount, setUpdatedCount] = useState(0);
+  const [skip, setSkip] = useState(0);
 
   useEffect(() => {
-    const url =
-      "https://mandarin.api.weniv.co.kr/post/" + accountname + "/userpost";
+    // 포스트 불러오기
     async function getPost() {
+      setSkip(0);
+      const url =
+        "https://mandarin.api.weniv.co.kr/post/" +
+        accountname +
+        "/userpost" +
+        "/?limit=15" +
+        "&skip=" +
+        skip;
       try {
         const res = await axios.get(url, {
           headers: {
@@ -27,6 +39,7 @@ function UserPost({ accountname, from }) {
             "Content-type": "application/json",
           },
         });
+        console.log(res);
         setPost(res.data.post);
       } catch (err) {
         console.error(err);
@@ -35,6 +48,64 @@ function UserPost({ accountname, from }) {
     getPost();
   }, [accountname, token, setReloadPost, isUpdate]);
 
+  useEffect(() => {
+    // 화면 마지막에 도달하면 ReloadNeed!
+    function infinitScoll() {
+      const postHeight = document
+        .querySelector(".wrapper-for-scroll")
+        .getBoundingClientRect().height;
+      const targetHeight = Math.floor(
+        Container.current.getBoundingClientRect().height + postHeight
+      );
+      const currentScrollY = Math.floor(window.scrollY + window.innerHeight);
+      targetHeight < currentScrollY && setReloadNeed(true);
+    }
+
+    window.addEventListener("scroll", infinitScoll);
+
+    // 스크롤시 데이터 추가 요청 함수
+    async function getPosts() {
+      const url =
+        "https://mandarin.api.weniv.co.kr/post/" +
+        accountname +
+        "/userpost" +
+        "/?limit=15" +
+        "&skip=" +
+        skip;
+      try {
+        const res = await axios.get(url, {
+          headers: {
+            Authorization: token,
+            "Content-type": "application/json",
+          },
+        });
+        // 첫 데이터면 전체 데이터 받아오기/데이터가 있으면 스프레드 문법 사용하여 추가하기
+        if (skip === 0) {
+          setPost(res.data.post);
+        } else {
+          setPost([...post, ...res.data.post]);
+        }
+        // 배열이 비어있으면 데이터 요청 차단
+        res.data.post.length === 0 && setReloadStop(true);
+        setUpdatedCount(updatedCount + 1);
+        setReloadNeed(false);
+        setSkip(skip + 15);
+        console.log(res);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    // 화면 마지막에 도달하면 infinite scroll 시작
+    if (reloadNeed === true) {
+      reloadStop || getPosts();
+    }
+    // 언마운트시에 스크롤이벤트 발생하지 않도록!
+    return () => {
+      window.removeEventListener("scroll", infinitScoll);
+    };
+  }, [token, post, updatedCount, reloadNeed, skip]);
+
+  // 앨범뷰 / 리스트뷰 선택
   function handleClick(e) {
     if (e.target.classList.contains("list")) {
       setPostView("list");
@@ -49,7 +120,7 @@ function UserPost({ accountname, from }) {
 
   return (
     <>
-      <section className="container-post">
+      <section className="container-post" ref={Container}>
         <h3 className="a11y-hidden">포스트 목록</h3>
         <div className="container-view-btn">
           <div className="wrapper-view-btn">

--- a/src/pages/profilePage/userPost/UserPost.scss
+++ b/src/pages/profilePage/userPost/UserPost.scss
@@ -49,12 +49,13 @@
 
 // 앨범 view 스타일
 .list-posts.album {
+  display: flex;
+  flex-wrap: wrap;
+  item-post {
+    width: 100% / 3;
+  }
   .article-post {
     background-color: $white;
-    float: left;
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
   }
   .contents-post {
     padding: 0;

--- a/src/pages/profilePage/userPost/UserPost.scss
+++ b/src/pages/profilePage/userPost/UserPost.scss
@@ -1,9 +1,11 @@
 @import "../../../components//style/default.scss";
 
 .container-post {
-  margin-top: 6px;
-  background-color: $white;
   height: auto;
+  margin-top: 6px;
+  border-top: 1px solid #dbdbdb;
+  background-color: $white;
+
   .wrapper-post {
     overflow: hidden;
     width: 390px;

--- a/src/scrollRestoration/ScrollToTop.jsx
+++ b/src/scrollRestoration/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
1. 피드페이지,프로필페이지,팔로우페이지 모두 무한스크롤 기능 구현하였습니다.
2. 중복된 코드들이 많은 것 같아서 개선할 수 있는 방법을 모색중입니다.
3. 페이지 이동시에 스크롤이 그 전페이지의 위치에 그대로 있는 문제(?) window.scrollTo 메서드로 해결하여 사용성을 개선하였습니다. 페이지 이동 시에 스크롤이 상단에 위치하게 됩니다. 