### PR TITLE
🔧 댓글,포스트 -분전 기능 추가

### DIFF
--- a/src/components/post/Article.jsx
+++ b/src/components/post/Article.jsx
@@ -14,7 +14,7 @@ function Article({ content, from, remove }) {
   const post = content;
   const author = content.author;
   const accountname = author.accountname;
-  const createAt = new Date(content.createdAt);
+  const createAtFull = new Date(content.createdAt);
   const [onModal, setOnModal] = useState(false);
 
   const img = ImageTest(post.image);
@@ -30,6 +30,25 @@ function Article({ content, from, remove }) {
     setOnModal(true);
   }
 
+  function createdAt(createdAt) {
+    const betweenTime = new Date() - createdAt;
+    const seconds = betweenTime / 1000;
+    if (seconds < 60) return `방금 전`;
+    const minutes = seconds / 60;
+    if (minutes < 60) return `${Math.floor(minutes)}분 전`;
+    const hours = minutes / 60;
+    if (hours < 24) return `${Math.floor(hours)}시간 전`;
+    const days = hours / 24;
+    if (days < 7) return `${Math.floor(days)}일 전`;
+    const weeks = days / 7;
+    if (weeks < 5) return `${Math.floor(weeks)}주 전`;
+    const months = days / 30;
+    if (months < 12) return `${Math.floor(months)}개월 전`;
+    const years = days / 365;
+    return `${Math.floor(years)}년 전`;
+  }
+
+  const commentCreatedAt = createdAt(createAtFull);
   return (
     <>
       <article className="article-post">
@@ -100,12 +119,14 @@ function Article({ content, from, remove }) {
             />
           </div>
           <strong className="text-post-date">
-            {createAt.getFullYear() +
-              "년 " +
-              (createAt.getMonth() + 1) +
-              "월 " +
-              createAt.getDate() +
-              "일"}
+            {from === "home"
+              ? commentCreatedAt
+              : createAtFull.getFullYear() +
+                "년 " +
+                (createAtFull.getMonth() + 1) +
+                "월 " +
+                createAtFull.getDate() +
+                "일"}
           </strong>
         </main>
         {onModal && (

--- a/src/pages/postDetailPage/comment/Comment.jsx
+++ b/src/pages/postDetailPage/comment/Comment.jsx
@@ -14,34 +14,29 @@ function Comment({ comments, postid, remove }) {
     setOnModal(true);
   }
 
-  function timeForToday(today, createAt) {
-    const betweenTime = Math.floor(
-      (today.getTime() - createAt.getTime()) / 1000 / 60
-    );
-    console.log(betweenTime);
-    if (betweenTime < 1) return "방금전";
-    if (betweenTime < 60) {
-      return `${betweenTime}분전`;
-    }
-    const betweenTimeHour = Math.floor(betweenTime / 60);
-    if (betweenTimeHour < 24) {
-      return `${betweenTimeHour}시간전`;
-    }
-
-    const betweenTimeDay = Math.floor(betweenTime / 60 / 24);
-    if (betweenTimeDay < 365) {
-      return `${betweenTimeDay}일전`;
-    }
-    return `${Math.floor(betweenTimeDay / 365)}년전`;
+  function createdAt(createdAt) {
+    const betweenTime = new Date() - createdAt;
+    const seconds = betweenTime / 1000;
+    if (seconds < 60) return `방금 전`;
+    const minutes = seconds / 60;
+    if (minutes < 60) return `${Math.floor(minutes)}분 전`;
+    const hours = minutes / 60;
+    if (hours < 24) return `${Math.floor(hours)}시간 전`;
+    const days = hours / 24;
+    if (days < 7) return `${Math.floor(days)}일 전`;
+    const weeks = days / 7;
+    if (weeks < 5) return `${Math.floor(weeks)}주 전`;
+    const months = days / 30;
+    if (months < 12) return `${Math.floor(months)}개월 전`;
+    const years = days / 365;
+    return `${Math.floor(years)}년 전`;
   }
 
   return (
     <>
       {comments &&
         comments.map((comment) => {
-          const today = new Date();
-          const createAt = new Date(comment.createdAt);
-          const timeAgo = timeForToday(today, createAt);
+          const commentCreatedAt = createdAt(new Date(comment.createdAt));
           return (
             <li className="item-comment" key={comment.id}>
               <Link to={"/" + comment.author.accountname}>
@@ -50,7 +45,7 @@ function Comment({ comments, postid, remove }) {
                   name={comment.author.username}
                   img={comment.author.image}
                 >
-                  <span className="text-comment-time">{timeAgo}</span>
+                  <span className="text-comment-time">{commentCreatedAt}</span>
                 </UserInfoBox>
               </Link>
               <p className="content-comment">{comment.content}</p>

--- a/src/pages/postDetailPage/comment/Comment.jsx
+++ b/src/pages/postDetailPage/comment/Comment.jsx
@@ -13,11 +13,35 @@ function Comment({ comments, postid, remove }) {
   function openModal() {
     setOnModal(true);
   }
+
+  function timeForToday(today, createAt) {
+    const betweenTime = Math.floor(
+      (today.getTime() - createAt.getTime()) / 1000 / 60
+    );
+    console.log(betweenTime);
+    if (betweenTime < 1) return "방금전";
+    if (betweenTime < 60) {
+      return `${betweenTime}분전`;
+    }
+    const betweenTimeHour = Math.floor(betweenTime / 60);
+    if (betweenTimeHour < 24) {
+      return `${betweenTimeHour}시간전`;
+    }
+
+    const betweenTimeDay = Math.floor(betweenTime / 60 / 24);
+    if (betweenTimeDay < 365) {
+      return `${betweenTimeDay}일전`;
+    }
+    return `${Math.floor(betweenTimeDay / 365)}년전`;
+  }
+
   return (
     <>
       {comments &&
         comments.map((comment) => {
+          const today = new Date();
           const createAt = new Date(comment.createdAt);
+          const timeAgo = timeForToday(today, createAt);
           return (
             <li className="item-comment" key={comment.id}>
               <Link to={"/" + comment.author.accountname}>
@@ -26,16 +50,7 @@ function Comment({ comments, postid, remove }) {
                   name={comment.author.username}
                   img={comment.author.image}
                 >
-                  {/* TODO -분 전으로 수정 by 현지*/}
-                  <span className="text-comment-time">
-                    {"· " +
-                      createAt.getFullYear() +
-                      "년 " +
-                      (createAt.getMonth() + 1) +
-                      "월 " +
-                      createAt.getDate() +
-                      "일"}
-                  </span>
+                  <span className="text-comment-time">{timeAgo}</span>
                 </UserInfoBox>
               </Link>
               <p className="content-comment">{comment.content}</p>


### PR DESCRIPTION
1. 기존에 -년-월-일로 보이던 댓글 UI를 시간이 얼마나 지났는지 구하는 함수를 사용하여 -분전, -일전,-년전 으로 보이도록 UI를 개선하였습니다.
2. 게시물 날짜도 피드페이지에서는 -분전, 상세페이지에서는 년,월,일로 보이도록 하였습니다.