### PR TITLE
🧹 프로필 에러이미지 적용 안된 컴포넌트 수정

### DIFF
--- a/src/components/post/Article.jsx
+++ b/src/components/post/Article.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Pagination } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
 import useImageTest from "../../hooks/useImageTest";
+import useProfileImageTest from "../../hooks/useProfileImageTest";
 import CommentBtn from "../button/CommentBtn";
 import LikeBtn from "../button/LikeBtn";
 import UserMoreBtn from "../button/UserMoreBtn";
@@ -16,6 +17,7 @@ import "swiper/scss/pagination";
 
 function Article({ content, from, remove }) {
   const { imageTest } = useImageTest();
+  const { profileImageTest } = useProfileImageTest();
   const post = content;
   const author = content.author;
   const accountname = author.accountname;
@@ -24,6 +26,7 @@ function Article({ content, from, remove }) {
 
   const img = imageTest(post.image);
   const imgArray = img.split(",");
+  const authorImg = profileImageTest(author.image);
 
   function handleImageError(e) {
     e.target.src = errorImage;
@@ -64,7 +67,7 @@ function Article({ content, from, remove }) {
               type="post"
               name={author.username}
               id={"@" + author.accountname}
-              img={author.image}
+              img={authorImg}
             ></UserInfoBox>
           </>
         ) : (
@@ -74,7 +77,7 @@ function Article({ content, from, remove }) {
                 type="post"
                 name={author.username}
                 id={"@" + author.accountname}
-                img={author.image}
+                img={authorImg}
               ></UserInfoBox>
             </Link>
           </>

--- a/src/hooks/useProfileImageTest.jsx
+++ b/src/hooks/useProfileImageTest.jsx
@@ -2,7 +2,7 @@ import defaultProfile from "../assets/4p_profile.png";
 
 // 에러이미지 예외처리 Hook
 function useProfileTest() {
-  function imageTest(img) {
+  function profileImageTest(img) {
     const testedImg =
       /Ellipse/.test(img) ||
       /heroku/.test(img) ||
@@ -16,7 +16,7 @@ function useProfileTest() {
 
     return testedImg;
   }
-  return { imageTest };
+  return { profileImageTest };
 }
 
 export default useProfileTest;

--- a/src/pages/followPage/followList/User.jsx
+++ b/src/pages/followPage/followList/User.jsx
@@ -16,7 +16,7 @@ function User({
   followers,
   isfollow,
 }) {
-  const { imageTest } = useProfileTest();
+  const { profileImageTest } = useProfileTest();
   const { myAccountname } = useContext(UserContext);
 
   const [user, setUser] = useState({
@@ -29,7 +29,7 @@ function User({
     isfollow: isfollow,
   });
 
-  const img = imageTest(user.image);
+  const img = profileImageTest(user.image);
 
   return (
     <>

--- a/src/pages/profilePage/userHeader/UserHeader.jsx
+++ b/src/pages/profilePage/userHeader/UserHeader.jsx
@@ -7,8 +7,8 @@ import useProfileTest from "../../../hooks/useProfileImageTest";
 import "./UserHeader.scss";
 
 function ProfileHeader({ from, setUser, user }) {
-  const { imageTest } = useProfileTest();
-  const img = imageTest(user.image);
+  const { profileImageTest } = useProfileTest();
+  const img = profileImageTest(user.image);
   const imgStyle = {
     backgroundImage: `url(${img})`,
   };

--- a/src/pages/searchUserPage/searchResult/SearchResult.jsx
+++ b/src/pages/searchUserPage/searchResult/SearchResult.jsx
@@ -6,7 +6,7 @@ import "./SearchResult.scss";
 import useProfileTest from "../../../hooks/useProfileImageTest";
 
 function SearchResult({ mapdata }) {
-  const { imageTest } = useProfileTest();
+  const { profileImageTest } = useProfileTest();
 
   function handleImageError(e) {
     e.target.src = defaultProfile;
@@ -15,7 +15,7 @@ function SearchResult({ mapdata }) {
   return (
     <ul className="search-result">
       {mapdata.map((user) => {
-        const img = imageTest(user.image);
+        const img = profileImageTest(user.image);
         return (
           <li key={user._id} className="list-search-user">
             <Link to={"/" + user.accountname}>


### PR DESCRIPTION
에러이미지 처리 두가지 hook의 함수이름이 동일하여 동시에 사용불가능한 문제, 함수이름 변경하여 해결하였습니다.
useInfoBox 컴포넌트에 예외처리 적용이 안돼있어서 추가 적용해주었습니다.